### PR TITLE
Issue1

### DIFF
--- a/gdocs-shortcode.php
+++ b/gdocs-shortcode.php
@@ -100,10 +100,10 @@ function ray_google_docs_shortcode( $atts ) {
 					break;
 
 				case 'small' :
-				default :
 					$width  = 480;
 					$height = 389;
-
+                    break;
+				default :
 					break;
 			}
 

--- a/gdocs-shortcode.php
+++ b/gdocs-shortcode.php
@@ -90,19 +90,33 @@ function ray_google_docs_shortcode( $atts ) {
 				case 'medium' :
 					$width  = 960;
 					$height = 749;
-
 					break;
 
 				case 'large' :
 					$width  = 1440;
 					$height = 1109;
-
 					break;
 
 				case 'small' :
 					$width  = 480;
 					$height = 389;
                     break;
+
+                case 'large-ws':
+                    $width = 1440;
+                    $height = 839;
+                    break;
+
+                case 'medium-ws':
+                    $width = 960;
+                    $height = 569;
+                    break;
+
+                case 'small-ws':
+                    $width = 480;
+                    $height = 299;
+                    break;
+
 				default :
 					break;
 			}

--- a/gdocs-shortcode.php
+++ b/gdocs-shortcode.php
@@ -97,11 +97,6 @@ function ray_google_docs_shortcode( $atts ) {
 					$height = 1109;
 					break;
 
-				case 'small' :
-					$width  = 480;
-					$height = 389;
-                    break;
-
                 case 'large-ws':
                     $width = 1440;
                     $height = 839;
@@ -116,6 +111,10 @@ function ray_google_docs_shortcode( $atts ) {
                     $width = 480;
                     $height = 299;
                     break;
+				case 'small' :
+					$width  = 480;
+					$height = 389;
+
 
 				default :
 					break;

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Here are some other custom parameters you can use with the shortcode:
 
 * "seamless" - This parameter is only applicable to Documents. If you enter "0", this will show the Google Docs header and footer.  Default value is "1", which means that no Google Docs header or footer will be shown.
 
-* "size" - This parameter is only applicable to Presentations.  You can enter in "small", "medium" or "large" to use the presentation preset sizes. Dimensions for these presets are: small (480x389), medium (960x749), large (1440x1109). To set a custom width and height, use the "width" and "height" parameters listed above instead.
+* "size" - This parameter is only applicable to Presentations.  You can enter in "small", "medium" or "large" to use the presentation preset sizes. Dimensions for these presets are: small (480x389), medium (960x749), large (1440x1109). For widescreen presentations, you can use "small-ws" (480x299), "medium-ws" (960x569), or "large-ws" (1440x839). To set a custom width and height, use the "width" and "height" parameters listed above instead.
 
 ***
 


### PR DESCRIPTION
Ok, I was wrong with the width and height parameters, that was working. The defaults are for 4:3 presentations. For widescreens you must put a width and heigth or it will pillarbox the presentation.

I added presets for the new Google widescreen presentations.